### PR TITLE
Nested Relationship with includeRelationship Method

### DIFF
--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -313,6 +313,20 @@ class TransformBuilder
                 return $eagerLoads;
             }
 
+            // Note, currently only works one level deep for now, ex. 'comments.user'
+            // Note, $transformer->relations must have transformer associated with each relation even if parent as includeRelation method
+            // because this is how we check the nested transformer,
+            // method_exists($transformer->relations[$parent], 'include' . ucfirst($nestedRelation))
+            $nestedRelations = explode('.', $identifier);
+            if (count($nestedRelations) > 1) {
+                $parent = $nestedRelations[0];
+                $nestedRelation = last($nestedRelations);
+
+                if (method_exists($transformer->getRelations()[$parent], 'include' . ucfirst($nestedRelation))) {
+                    return $eagerLoads;
+                }
+            }
+
             return array_merge($eagerLoads, [$identifier => $requested[$relation] ?: function () { }]);
         }, []);
 

--- a/src/Transformers/Concerns/HasRelationships.php
+++ b/src/Transformers/Concerns/HasRelationships.php
@@ -30,6 +30,16 @@ trait HasRelationships
     protected $load = [];
 
     /**
+     * Get list of available relations.
+     *
+     * @return array
+     */
+    public function getRelations(): array
+    {
+        return $this->relations;
+    }
+
+    /**
      * Get a list of whitelisted relations that are requested, including nested relations.
      *
      * @param  array $requested


### PR DESCRIPTION
Hello,

First off, Thanks for the package!  

In reducing query count I found that I didn't want eager-load a nested relationship.  The following pseudo code hopefully explains the situation.



```
/// PostController
responder()->success($posts, PostTransformer::class)->with('comments.user')->response();

/// PostTransformer 
relations = ['comments' => CommentsTransformer::class']

/// CommentsTransformer
relations = ['user' => UserTransformer::class];
includeUser() { // ... do whatever, ex. grab user from cache instead of eager-load // }
```

Let me know, thanks!