### PR TITLE
PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "illuminate/contracts": "^5.1|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.1|^6.0|^7.0|^8.0",
         "league/fractal": "^0.17.0"
@@ -28,7 +28,6 @@
         "illuminate/database": "^5.1|^6.0|^7.0|^8.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "mockery/mockery": "^0.9.5|^1.0",
-        "fzaninotto/faker": "^1.6",
         "doctrine/dbal": "^2.5",
         "phpunit/phpunit": "^8.5|^9.0"
     },


### PR DESCRIPTION
PHP version update and fzaninotto/faker reference removal. Tests run smoothly with php 8.0