### PR TITLE
update method signature of getAvailableIncludes and getDefauttIncludes

### DIFF
--- a/src/Transformers/Concerns/OverridesFractal.php
+++ b/src/Transformers/Concerns/OverridesFractal.php
@@ -19,7 +19,7 @@ trait OverridesFractal
      *
      * @return array
      */
-    public function getAvailableIncludes()
+    public function getAvailableIncludes() : array
     {
         if ($this->relations == ['*']) {
             return $this->resolveScopedIncludes($this->getCurrentScope());
@@ -33,7 +33,7 @@ trait OverridesFractal
      *
      * @return array
      */
-    public function getDefaultIncludes()
+    public function getDefaultIncludes() : array
     {
         return array_keys($this->normalizeRelations($this->load));
     }


### PR DESCRIPTION
this pr is for small fix for this fatal error:

- Declaration of Flugg\Responder\Transformers\Concerns\OverridesFractal::getAvailableIncludes() must be compatible with League\Fractal\TransformerAbstract::getAvailableIncludes(): array
- Declaration of Flugg\Responder\Transformers\Concerns\OverridesFractal::getDefaultIncludes() must be compatible with League\Fractal\TransformerAbstract::getDefaultIncludes(): array

