### PR TITLE
Update NoopSerializer.php

### DIFF
--- a/src/Serializers/NoopSerializer.php
+++ b/src/Serializers/NoopSerializer.php
@@ -46,7 +46,7 @@ class NoopSerializer extends SuccessSerializer
      *
      * @return array
      */
-    public function null(): array
+    public function null(): null
     {
         return null;
     }


### PR DESCRIPTION
fix: Return value must be null not array