### PR TITLE
Fix Flugg\Responder\Serializers\NoopSerializer::null(): Return value 

### DIFF
--- a/src/Serializers/NoopSerializer.php
+++ b/src/Serializers/NoopSerializer.php
@@ -48,7 +48,7 @@ class NoopSerializer extends SuccessSerializer
      */
     public function null(): array
     {
-        return null;
+        return [];
     }
 
     /**


### PR DESCRIPTION
Fix Flugg\Responder\Serializers\NoopSerializer::null(): Return value  must be of type array, null returned


![image](https://github.com/flugg/laravel-responder/assets/93094459/a5d8e64b-e268-4916-988c-455a11961235)

![image](https://github.com/flugg/laravel-responder/assets/93094459/9099f700-a23f-4c9e-9bee-f27537ad584d)

