### PR TITLE
Change UnauthorizedException http code from 403 to 401

### DIFF
--- a/src/Exceptions/Http/UnauthorizedException.php
+++ b/src/Exceptions/Http/UnauthorizedException.php
@@ -17,7 +17,7 @@ class UnauthorizedException extends HttpException
      *
      * @var int
      */
-    protected $status = 403;
+    protected $status = 401;
 
     /**
      * An error code.


### PR DESCRIPTION
The HTTP standard clearly defines Unauthorized as 401. This change is intended to adhere to said standard.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401